### PR TITLE
Cleanup card name parsing

### DIFF
--- a/TrelloMigrate/Transform.fs
+++ b/TrelloMigrate/Transform.fs
@@ -46,12 +46,12 @@ module private Speaker =
 
     let tryParseCardName (card : BasicCard) = 
         let tryGetValue (group : Group) = 
-            if group.Success then Some group.Value
+            if group.Success && not <| String.IsNullOrWhiteSpace group.Value then Some <| group.Value.Trim()
             else None
         
-        let m = Regex.Match(card.Name, "(?<name>[^\[\]]* )(\[(?<email>.*)\])? *\((?<talk>.*)\)(?<extra>.*)?$", RegexOptions.ExplicitCapture)
+        let m = Regex.Match(card.Name, "(?<name>[^\[\]]* *)(\[(?<email>.*)\])? *\((?<talk>.*)\)(?<extra>.*)?$", RegexOptions.ExplicitCapture)
         if m.Success && m.Groups.["name"].Success && not <| String.IsNullOrWhiteSpace m.Groups.["name"].Value then 
-            { SpeakerName = m.Groups.["name"].Value
+            { SpeakerName = m.Groups.["name"].Value.Trim()
               SpeakerEmail = tryGetValue m.Groups.["email"]
               TalkData = tryGetValue m.Groups.["talk"]
               ExtraData = tryGetValue m.Groups.["extra"] }

--- a/TrelloMigrate/Transform.fs
+++ b/TrelloMigrate/Transform.fs
@@ -44,16 +44,18 @@ module private Profile =
 
 module private Speaker = 
 
-    let tryGetValue (group: Group) = if group.Success then Some group.Value else None
-
     let tryParseCardName (card : BasicCard) = 
-        let options = RegexOptions.ExplicitCapture
-        let m = Regex.Match(card.Name, "(?<name>[^\[\]]* )(\[(?<email>.*)\])? *\((?<talk>.*)\)(?<extra>.*)?$", options)
-        if m.Success && m.Groups.["name"].Success then
+        let tryGetValue (group : Group) = 
+            if group.Success then Some group.Value
+            else None
+        
+        let m = Regex.Match(card.Name, "(?<name>[^\[\]]* )(\[(?<email>.*)\])? *\((?<talk>.*)\)(?<extra>.*)?$", RegexOptions.ExplicitCapture)
+        if m.Success && m.Groups.["name"].Success && not <| String.IsNullOrWhiteSpace m.Groups.["name"].Value then 
             { SpeakerName = m.Groups.["name"].Value
               SpeakerEmail = tryGetValue m.Groups.["email"]
               TalkData = tryGetValue m.Groups.["talk"]
-              ExtraData = tryGetValue m.Groups.["extra"] } |> Some
+              ExtraData = tryGetValue m.Groups.["extra"] }
+            |> Some
         else None
 
     //Note: Currently ignoring any cards that don't have the title (name) filled out correctly. 

--- a/TrelloMigrate/Transform.fs
+++ b/TrelloMigrate/Transform.fs
@@ -51,10 +51,7 @@ module private Speaker =
         
         let m = Regex.Match(card.Name, "(?<name>[^\[\]]* *)\[(?<email>.*)\] *\((?<talk>.*)\)(?<extra>.*)?$", RegexOptions.ExplicitCapture)
         if m.Success && m.Groups.["name"].Success && not <| String.IsNullOrWhiteSpace m.Groups.["name"].Value then 
-            { SpeakerName = m.Groups.["name"].Value.Trim()
-              SpeakerEmail = tryGetValue m.Groups.["email"]
-              TalkData = tryGetValue m.Groups.["talk"]
-              ExtraData = tryGetValue m.Groups.["extra"] }
+            { SpeakerName = m.Groups.["name"].Value.Trim() }
             |> Some
         else None
 

--- a/TrelloMigrate/Transform.fs
+++ b/TrelloMigrate/Transform.fs
@@ -49,7 +49,7 @@ module private Speaker =
             if group.Success && not <| String.IsNullOrWhiteSpace group.Value then Some <| group.Value.Trim()
             else None
         
-        let m = Regex.Match(card.Name, "(?<name>[^\[\]]* *)(\[(?<email>.*)\])? *\((?<talk>.*)\)(?<extra>.*)?$", RegexOptions.ExplicitCapture)
+        let m = Regex.Match(card.Name, "(?<name>[^\[\]]* *)\[(?<email>.*)\] *\((?<talk>.*)\)(?<extra>.*)?$", RegexOptions.ExplicitCapture)
         if m.Success && m.Groups.["name"].Success && not <| String.IsNullOrWhiteSpace m.Groups.["name"].Value then 
             { SpeakerName = m.Groups.["name"].Value.Trim()
               SpeakerEmail = tryGetValue m.Groups.["email"]

--- a/TrelloMigrate/TransformationModels.fs
+++ b/TrelloMigrate/TransformationModels.fs
@@ -6,7 +6,4 @@ type Names =
       Surname : string }
 
 type CardNameParseData = 
-    { SpeakerName : string 
-      SpeakerEmail : string option 
-      TalkData : string option 
-      ExtraData : string option }
+    { SpeakerName : string }

--- a/TrelloMigrate/TransformationModels.fs
+++ b/TrelloMigrate/TransformationModels.fs
@@ -5,7 +5,7 @@ type Names =
     { Forename : string
       Surname : string }
 
-type CardNameParse = 
+type CardNameParseData = 
     { SpeakerName : string 
       SpeakerEmail : string option 
       TalkData : string option 

--- a/TrelloMigrate/TransformationModels.fs
+++ b/TrelloMigrate/TransformationModels.fs
@@ -4,3 +4,9 @@ open SrmApiModels
 type Names = 
     { Forename : string
       Surname : string }
+
+type CardNameParse = 
+    { SpeakerName : string 
+      SpeakerEmail : string option 
+      TalkData : string option 
+      ExtraData : string option }


### PR DESCRIPTION
Changes to deal with whitespace. Named group capture was added to deal with subgroups and to make things a bit clearer. 